### PR TITLE
UI: Hovering a player now shows a list of point events

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,30 @@
             flex-basis: max-content;
             align-self: center;
         }
+        .player-events {
+            border: 1px solid black;
+            background-color: white;
+            padding: 5px;
+            position: absolute;
+            display: none;
+            margin-right: auto;
+        }
+        .player-name:hover .player-events {
+            display: flex;
+        }
+        .player-events:hover {
+            display: none !important;
+        }
+        .player-point-event-table tr {
+            border-top: 1px solid gray;
+            border-bottom: 1px solid gray;
+        }
+        .player-point-event-table thead {
+            background-color: lightgray;
+        }
+        .integer {
+            text-align: right;
+        }
     </style>
     <style>
         .current-gw-points {
@@ -42,6 +66,28 @@
                 {% for player in manager.team.get_players_at_position('gkp') %}
                     <span class="player-name">
                         {{ player.static.name }} [{{ player.gw_points }}]
+                        <span class="player-events">
+                            <table class="player-point-event-table">
+                                <thead>
+                                    <tr>
+                                        <th><b>Name</b></th>
+                                        <th><b>Unitpoint</b></th>
+                                        <th><b>#</b></th>
+                                        <th><b>Total</b></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for event in player.events %}
+                                    <tr>
+                                        <td>{{ event.event }}</td>
+                                        <td>{{ event.unit_point }}</td>
+                                        <td class="integer">{{ event.count }}</td>
+                                        <td class="integer">{{ event.points }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </span>
                     </span>
                 {% endfor %}
                 </div>
@@ -50,6 +96,28 @@
                 {% for player in manager.team.get_players_at_position('def') %}
                     <span class="player-name">
                         {{ player.static.name }} [{{ player.gw_points }}]
+                        <span class="player-events">
+                            <table class="player-point-event-table">
+                                <thead>
+                                    <tr>
+                                        <th><b>Name</b></th>
+                                        <th><b>Unitpoint</b></th>
+                                        <th><b>#</b></th>
+                                        <th><b>Total</b></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for event in player.events %}
+                                    <tr>
+                                        <td>{{ event.event }}</td>
+                                        <td>{{ event.unit_point }}</td>
+                                        <td class="integer">{{ event.count }}</td>
+                                        <td class="integer">{{ event.points }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </span>
                     </span>
                 {% endfor %}
                 </div>
@@ -58,6 +126,28 @@
                 {% for player in manager.team.get_players_at_position('mid') %}
                     <span class="player-name">
                         {{ player.static.name }} [{{ player.gw_points }}]
+                        <span class="player-events">
+                            <table class="player-point-event-table">
+                                <thead>
+                                    <tr>
+                                        <th><b>Name</b></th>
+                                        <th><b>Unitpoint</b></th>
+                                        <th><b>#</b></th>
+                                        <th><b>Total</b></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for event in player.events %}
+                                    <tr>
+                                        <td>{{ event.event }}</td>
+                                        <td>{{ event.unit_point }}</td>
+                                        <td class="integer">{{ event.count }}</td>
+                                        <td class="integer">{{ event.points }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </span>
                     </span>
                 {% endfor %}
                 </div>
@@ -66,6 +156,28 @@
                 {% for player in manager.team.get_players_at_position('fwd') %}
                     <span class="player-name">
                         {{ player.static.name }} [{{ player.gw_points }}]
+                        <span class="player-events">
+                            <table class="player-point-event-table">
+                                <thead>
+                                    <tr>
+                                        <th><b>Name</b></th>
+                                        <th><b>Unitpoint</b></th>
+                                        <th><b>#</b></th>
+                                        <th><b>Total</b></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for event in player.events %}
+                                    <tr>
+                                        <td>{{ event.event }}</td>
+                                        <td>{{ event.unit_point }}</td>
+                                        <td class="integer">{{ event.count }}</td>
+                                        <td class="integer">{{ event.points }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </span>
                     </span>
                 {% endfor %}
                 </div>
@@ -79,6 +191,28 @@
                         {% for player in players %}
                             <span class="player-name">
                                 {{ player.static.name }} [{{ player.gw_points }}]
+                                <span class="player-events">
+                                    <table class="player-point-event-table">
+                                        <thead>
+                                            <tr>
+                                                <th><b>Name</b></th>
+                                                <th><b>Unitpoint</b></th>
+                                                <th><b>#</b></th>
+                                                <th><b>Total</b></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for event in player.events %}
+                                            <tr>
+                                                <td>{{ event.event }}</td>
+                                                <td>{{ event.unit_point }}</td>
+                                                <td class="integer">{{ event.count }}</td>
+                                                <td class="integer">{{ event.points }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </span>
                             </span>
                         {% endfor %}
                     {% else %}
@@ -92,6 +226,28 @@
                         {% for player in players %}
                             <span class="player-name">
                                 {{ player.static.name }} [{{ player.gw_points }}]
+                                <span class="player-events">
+                                    <table class="player-point-event-table">
+                                        <thead>
+                                            <tr>
+                                                <th><b>Name</b></th>
+                                                <th><b>Unitpoint</b></th>
+                                                <th><b>#</b></th>
+                                                <th><b>Total</b></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for event in player.events %}
+                                            <tr>
+                                                <td>{{ event.event }}</td>
+                                                <td>{{ event.unit_point }}</td>
+                                                <td class="integer">{{ event.count }}</td>
+                                                <td class="integer">{{ event.points }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </span>
                             </span>
                         {% endfor %}
                     {% else %}
@@ -105,6 +261,28 @@
                         {% for player in players %}
                             <span class="player-name">
                                 {{ player.static.name }} [{{ player.gw_points }}]
+                                <span class="player-events">
+                                    <table class="player-point-event-table">
+                                        <thead>
+                                            <tr>
+                                                <th><b>Name</b></th>
+                                                <th><b>Unitpoint</b></th>
+                                                <th><b>#</b></th>
+                                                <th><b>Total</b></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for event in player.events %}
+                                            <tr>
+                                                <td>{{ event.event }}</td>
+                                                <td>{{ event.unit_point }}</td>
+                                                <td class="integer">{{ event.count }}</td>
+                                                <td class="integer">{{ event.points }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </span>
                             </span>
                         {% endfor %}
                     {% else %}
@@ -118,6 +296,28 @@
                         {% for player in players %}
                             <span class="player-name">
                                 {{ player.static.name }} [{{ player.gw_points }}]
+                                <span class="player-events">
+                                    <table class="player-point-event-table">
+                                        <thead>
+                                            <tr>
+                                                <th><b>Name</b></th>
+                                                <th><b>Unitpoint</b></th>
+                                                <th><b>#</b></th>
+                                                <th><b>Total</b></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for event in player.events %}
+                                            <tr>
+                                                <td>{{ event.event }}</td>
+                                                <td>{{ event.unit_point }}</td>
+                                                <td class="integer">{{ event.count }}</td>
+                                                <td class="integer">{{ event.points }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </span>
                             </span>
                         {% endfor %}
                     {% else %}


### PR DESCRIPTION
Closes #2 

In the UI, a user can now get a list of point events that shows the
source of a player's points. The list is only shown when a player's
name is hovered and disappears otherwise.

The current solution was a quick one and is not very clean, as the UI
may change soon anyway.