### PR TITLE
Util: Fixed a bug in the timed cache util

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -17,7 +17,7 @@ class TimedCache:
         @wraps(func)
         def inner(*args, **kw):
             if self._should_cache_update():
-                print('Updating...')
                 self.cached_result = func(*args, **kw)
+                self.cached_time = datetime.datetime.now()
             return self.cached_result
         return inner


### PR DESCRIPTION
Closes #9 

The timed cache did not update its internal timestamp, causing it to
update every request after the given time from runtime start.

The cache now correctly updates the timestamp and functions as intended.