### PR TITLE
Core: The gameweek now updates with state

### DIFF
--- a/server.py
+++ b/server.py
@@ -9,21 +9,21 @@ app = Flask(__name__)
 
 @app.route('/')
 def index():
-    manager_data = fpl.get_current_state()
+    current_info = fpl.get_current_state()
     return render_template(
         'index.html',
-        teams=manager_data,
-        gameweek=fpl.GAMEWEEK)
+        teams=current_info.managers,
+        gameweek=current_info.gameweek)
 
 @app.errorhandler(404)
 def catch_all(path):
-    time.sleep(random.randint(2, 6))
+    time.sleep(random.randint(10, 30))
 
-    manager_data = fpl.get_current_state()
+    current_info = fpl.get_current_state()
     return render_template(
         'index.html',
-        teams=manager_data,
-        gameweek=fpl.GAMEWEEK), 500
+        teams=current_info.managers,
+        gameweek=current_info.gameweek)
 
 if __name__ == '__main__':
     import os

--- a/src/fpl.py
+++ b/src/fpl.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import time
+from collections import namedtuple
 
 from . import static
 from . import api
@@ -10,6 +11,7 @@ league_data = api.StaticInfo.noslack_league()
 static_info = api.StaticInfo.premier_league()
 
 GAMEWEEK = static_info['events']['current']
+GameweekInfo = namedtuple('GameweekInfo', ['managers', 'gameweek'])
 
 class Manager:
     def __init__(self, team_id, name, team_name, points=0):
@@ -144,10 +146,11 @@ team_data = [
 @TimedCache(datetime.timedelta(minutes=1))
 def get_current_state():
     managers = list(star2map(Manager.from_api, team_data))
-    teams = [manager.fetch_gw_team(GAMEWEEK)
+    gameweek = api.StaticInfo.premier_league()['events']['current']
+    teams = [manager.fetch_gw_team(gameweek)
              for manager in managers]
 
-    current_info = api.DynamicInfo.gameweek_stats(GAMEWEEK)
+    current_info = api.DynamicInfo.gameweek_stats(gameweek)
 
     gw_points = [sum(team.current_points(current_info))
                  if team is not None else 0
@@ -162,5 +165,5 @@ def get_current_state():
     managers = sorted(managers, key=lambda m: m.points + m.gw_points,
                       reverse=True)
 
-    return managers
+    return GameweekInfo(managers, gameweek)
 


### PR DESCRIPTION
Closes #8 

Now fetches the current gameweek while updating the state. This makes
the gameweek info update automatically when the gameweek has started.

I also made the return value a `namedtuple` to self-document the code.