### PR TITLE
UI: Benchable players are now marked with italic

### DIFF
--- a/src/fpl.py
+++ b/src/fpl.py
@@ -96,6 +96,12 @@ class Player:
     def benched(self):
         return self.position >= 12
 
+    def will_be_benched(self, gameweek):
+        res = (self.static.plteam.has_played(gameweek)
+               and self.events[0].points == 0)
+        print(self, res, self.events)
+        return res
+
     def point_events_from_data(self, data):
         events =  list(star2map(PlayerEvent.from_api,
                                 data['elements'][str(self.id)]['explain'][0][0]))

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,9 @@
         .black {
             color: black;
         }
+        .italic {
+            font-style: italic;
+        }
     </style>
     <style>
         .current-gw-points {
@@ -74,7 +77,8 @@
             <div style="display: flex; flex-direction: column; width: 50%; align-items: center; justify-content: space-evenly;">
                 <div style="display: flex; flex-direction: row;">
                 {% for player in manager.team.get_players_at_position('gkp') %}
-                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                             {{ 'italic' if player.will_be_benched(gameweek) }}">
                         {{ player.static.name }}
                         ({{ player.static.plteam.shortname }})
                         [{{ player.gw_points }}]
@@ -106,7 +110,8 @@
                 <br>
                 <div style="display: flex; flex-direction: row; justify-content: space-evenly; width:100%">
                 {% for player in manager.team.get_players_at_position('def') %}
-                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                             {{ 'italic' if player.will_be_benched(gameweek) }}">
                         {{ player.static.name }}
                         ({{ player.static.plteam.shortname }})
                         [{{ player.gw_points }}]
@@ -138,7 +143,8 @@
                 <br>
                 <div style="display: flex; flex-direction: row; justify-content: space-evenly; width:100%">
                 {% for player in manager.team.get_players_at_position('mid') %}
-                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                             {{ 'italic' if player.will_be_benched(gameweek) }}">
                         {{ player.static.name }}
                         ({{ player.static.plteam.shortname }})
                         [{{ player.gw_points }}]
@@ -170,7 +176,8 @@
                 <br>
                 <div style="display: flex; flex-direction: row; justify-content: space-evenly; width:100%">
                 {% for player in manager.team.get_players_at_position('fwd') %}
-                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                    <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                             {{ 'italic' if player.will_be_benched(gameweek) }}">
                         {{ player.static.name }}
                         ({{ player.static.plteam.shortname }})
                         [{{ player.gw_points }}]
@@ -207,7 +214,8 @@
                     {% set players = manager.team.get_players_at_position('gkp', on_field=False) %}
                     {% if players|length > 0%}
                         {% for player in players %}
-                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                                     {{ 'italic' if player.will_be_benched(gameweek) }}">
                                 {{ player.static.name }}
                                 ({{ player.static.plteam.shortname }})
                                 [{{ player.gw_points }}]
@@ -244,7 +252,8 @@
                     {% set players = manager.team.get_players_at_position('def', on_field=False) %}
                     {% if players|length > 0%}
                         {% for player in players %}
-                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                                     {{ 'italic' if player.will_be_benched(gameweek) }}">
                                 {{ player.static.name }}
                                 ({{ player.static.plteam.shortname }})
                                 [{{ player.gw_points }}]
@@ -281,7 +290,8 @@
                     {% set players = manager.team.get_players_at_position('mid', on_field=False) %}
                     {% if players|length > 0%}
                         {% for player in players %}
-                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                                     {{ 'italic' if player.will_be_benched(gameweek) }}">
                                 {{ player.static.name }}
                                 ({{ player.static.plteam.shortname }})
                                 [{{ player.gw_points }}]
@@ -318,7 +328,8 @@
                     {% set players = manager.team.get_players_at_position('fwd', on_field=False) %}
                     {% if players|length > 0%}
                         {% for player in players %}
-                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}">
+                            <span class="player-name {{ 'black' if player.static.plteam.has_played(gameweek) else 'green' }}
+                                                     {{ 'italic' if player.will_be_benched(gameweek) }}">
                                 {{ player.static.name }}
                                 ({{ player.static.plteam.shortname }})
                                 [{{ player.gw_points }}]


### PR DESCRIPTION
Closes #3 

Benchable players' names now appear in italic if their team has played
and they have no points, indicating that they will be benched (if other
rules allow it).